### PR TITLE
Tokenizer optimizations

### DIFF
--- a/+bert/+tokenizer/+internal/BasicTokenizer.m
+++ b/+bert/+tokenizer/+internal/BasicTokenizer.m
@@ -34,12 +34,11 @@ classdef BasicTokenizer < bert.tokenizer.internal.Tokenizer
             u = this.cleanText(u);
             u = this.tokenizeCJK(u);
             text = u.string();
-            origTokens = this.whiteSpaceTokenize(text);
             if this.IgnoreCase
-                origTokens = lower(origTokens);
-                origTokens = textanalytics.unicode.nfd(origTokens);
+                text = lower(text);
+                text = textanalytics.unicode.nfd(text);
             end
-            u = textanalytics.unicode.UTF32(origTokens);
+            u = textanalytics.unicode.UTF32(text);
             cats = u.characterCategories('Granularity','detailed');
             if this.IgnoreCase
                 [u,cats] = this.stripAccents(u,cats);

--- a/+bert/+tokenizer/+internal/FullTokenizer.m
+++ b/+bert/+tokenizer/+internal/FullTokenizer.m
@@ -85,9 +85,10 @@ classdef FullTokenizer < bert.tokenizer.internal.Tokenizer
             %   tokens = tokenize(tokenizer,text) tokenizes the input
             %   string text using the FullTokenizer specified by tokenizer.
             basicToks = this.Basic.tokenize(txt);
+            basicToksUnicode = textanalytics.unicode.UTF32(basicToks);
             subToks = cell(numel(basicToks),1);
             for i = 1:numel(basicToks)
-                subToks{i} = this.WordPiece.tokenize(basicToks{i});
+                subToks{i} = this.WordPiece.tokenize(basicToksUnicode(i));
             end
             toks = cat(2,subToks{:});
         end

--- a/+bert/+tokenizer/+internal/WhitespaceTokenizer.m
+++ b/+bert/+tokenizer/+internal/WhitespaceTokenizer.m
@@ -10,7 +10,7 @@ classdef WhitespaceTokenizer < bert.tokenizer.internal.Tokenizer
             %                              by splitting str on whitespace.
             arguments
                 ~
-                text (1,1) string
+                text
             end
             text = strip(text);
             text = split(text).';

--- a/+bert/+tokenizer/+internal/WordPieceTokenizer.m
+++ b/+bert/+tokenizer/+internal/WordPieceTokenizer.m
@@ -63,8 +63,9 @@ classdef WordPieceTokenizer < bert.tokenizer.internal.Tokenizer
                         if start>1
                             sub.Data = [uint32('##'),sub.Data];
                         end
-                        if this.Vocab.isVocabularyWord(sub.string())
-                            currentSub = sub.string();
+                        strForm = sub.string();
+                        if this.Vocab.isVocabularyWord(strForm)
+                            currentSub = strForm;
                             break
                         end
                         finish = finish-1;

--- a/+bert/+tokenizer/+internal/WordPieceTokenizer.m
+++ b/+bert/+tokenizer/+internal/WordPieceTokenizer.m
@@ -37,16 +37,15 @@ classdef WordPieceTokenizer < bert.tokenizer.internal.Tokenizer
             this.Vocab = this.parseVocab(vocab);
         end
         
-        function tokens = tokenize(this,text)
+        function tokens = tokenize(this,utext)
             arguments
                 this
-                text (1,1) string
+                utext
             end
             tokens = string.empty();
-            wsTokens = this.WhitespaceTokenizer.tokenize(text);
-            wsTokensU = textanalytics.unicode.UTF32(wsTokens);
-            for i = 1:numel(wsTokensU)
-                token = wsTokensU(i);
+            sub = textanalytics.unicode.UTF32();
+            for i = 1:numel(utext)
+                token = utext(i);
                 if numel(token.Data)>this.MaxChar
                     tokens = [tokens,this.Unk]; %#ok
                     continue
@@ -57,8 +56,7 @@ classdef WordPieceTokenizer < bert.tokenizer.internal.Tokenizer
                 while start<(numel(token.Data)+1)
                     finish = numel(token.Data);
                     currentSub = [];
-                    while start<finish+1
-                        sub = textanalytics.unicode.UTF32();
+                    while start<finish+1                        
                         sub.Data = token.Data(start:finish);
                         if start>1
                             sub.Data = [uint32('##'),sub.Data];

--- a/test/bert/tokenizer/internal/tWordPieceTokenizer.m
+++ b/test/bert/tokenizer/internal/tWordPieceTokenizer.m
@@ -39,7 +39,8 @@ classdef(SharedTestFixtures = {
             tok = bert.tokenizer.internal.WordPieceTokenizer(enc,'UnknownToken',unk);
             test.verifyEqual(tok.Unk,unk)
             str = "blah";
-            act_out = tok.tokenize(str);
+            ustr = textanalytics.unicode.UTF32(str);
+            act_out = tok.tokenize(ustr);
             exp_out = unk;
             test.verifyEqual(act_out,exp_out);
         end
@@ -50,7 +51,8 @@ classdef(SharedTestFixtures = {
             tok = bert.tokenizer.internal.WordPieceTokenizer(enc,'MaxTokenLength',maxLen);
             test.verifyEqual(tok.MaxChar,maxLen);
             str = "foo";
-            act_out = tok.tokenize(str);
+            ustr = textanalytics.unicode.UTF32(str);
+            act_out = tok.tokenize(ustr);
             exp_out = tok.Unk;
             test.verifyEqual(act_out,exp_out);
         end
@@ -59,7 +61,9 @@ classdef(SharedTestFixtures = {
             enc = wordEncoding(["foo","bar","##foo"]);
             tok = bert.tokenizer.internal.WordPieceTokenizer(enc);
             str = "foo bar foobar barba bafoobar barfoo";
-            act_out = tok.tokenize(str);
+            wsTok = bert.tokenizer.internal.WhitespaceTokenizer;
+            ustr = textanalytics.unicode.UTF32(wsTok.tokenize(str));
+            act_out = tok.tokenize(ustr);
             exp_out = ["foo","bar",tok.Unk,tok.Unk,tok.Unk,"bar","##foo"];
             test.verifyEqual(act_out,exp_out);
         end


### PR DESCRIPTION
A few things that speed up the tokenizer, about 2-3x from cases I've checked:

1. Remove redundant white-space tokenization in `BasicTokenizer`
2. Convert basic tokenized tokens to `UTF32` in one call in `FullTokenizer`, and modify `WordPieceTokenizer` to accept `UTF32` as input.
3. Only call `sub.string()` once in `WordPieceTokenizer`.
4. Remove input validation in `WhitespaceTokenizer` which may be called many times.

Not found any differences in tokenizations I've tried. The changes in `BasicTokenizer` should be fine if `WhitespaceTokenizer.tokenize` commutes with the operations that follow (`lower`,`nfd`,splitting on punctuation) since there is already a final call to `WhitespaceTokenizer.tokenize`. The change in `WordPieceTokenizer`/`FullTokenizer` is fine given `WhitespaceTokenizer.tokenize(WhitespaceTokenizer.tokenize(x)) = WhitespaceTokenizer.tokenize(x)` in every case (which seems reasonable).