### PR TITLE
Remove unnecessary split

### DIFF
--- a/+bert/+tokenizer/+internal/WordPieceTokenizer.m
+++ b/+bert/+tokenizer/+internal/WordPieceTokenizer.m
@@ -35,9 +35,6 @@ classdef WordPieceTokenizer < bert.tokenizer.internal.Tokenizer
             this.Unk = nvp.UnknownToken;
             this.MaxChar = nvp.MaxTokenLength;
             this.Vocab = this.parseVocab(vocab);
-            
-            
-            
         end
         
         function tokens = tokenize(this,text)

--- a/+bert/+tokenizer/+internal/WordPieceTokenizer.m
+++ b/+bert/+tokenizer/+internal/WordPieceTokenizer.m
@@ -35,6 +35,9 @@ classdef WordPieceTokenizer < bert.tokenizer.internal.Tokenizer
             this.Unk = nvp.UnknownToken;
             this.MaxChar = nvp.MaxTokenLength;
             this.Vocab = this.parseVocab(vocab);
+            
+            
+            
         end
         
         function tokens = tokenize(this,text)
@@ -98,7 +101,7 @@ classdef WordPieceTokenizer < bert.tokenizer.internal.Tokenizer
             c = fread(fid,Inf);
             fclose(fid);
             c = native2unicode(c,'utf-8');%#ok
-            words = split(splitlines(c')).';
+            words = splitlines(c').';
             empties = cellfun(@isempty,words);
             words(empties) = [];
             vocab = wordEncoding(words);


### PR DESCRIPTION
This call to split whilst parsing the vocab is unnecessary, and causes an error in a token in the vocab has whitespace.

The case where a vocabulary token has a space (e.g. "hello world") isn't going to work in any reasonable way currently since a bunch of the tokenization is based on white-space tokenization, but it seems harmless to remove this split in the meantime.