### PR TITLE
Add compatibility code for gpt2

### DIFF
--- a/+gpt2/+internal/getSupportFilePath.m
+++ b/+gpt2/+internal/getSupportFilePath.m
@@ -7,6 +7,10 @@ function filePath = getSupportFilePath(fileName)
 arguments
     fileName (1,1) string
 end
+if ismember(version('-release'),["2020a","2020b"])
+    filePath = legacySupportFilePath(fileName);
+    return
+end
 sd = matlab.internal.examples.utils.getSupportFileDir();
 localFileDir = {"data","networks"};%#ok
 localFile = fullfile(sd,"nnet",localFileDir{:},fileName);
@@ -15,4 +19,37 @@ if exist(localFile,'file')~=2
 end
 fileURL = strjoin([localFileDir,fileName],"/");
 filePath = matlab.internal.examples.downloadSupportFile("nnet",fileURL);
+end
+
+function filePath = legacySupportFilePath(fileName)
+% For releases before matlab.internal.examples.downloadSupportFile,
+% use manual download code. We save to the repo's root directory instead of
+% the userpath.
+% Create directories for the model.
+modelType = 'gpt2-355M';
+modelDirectory = fullfile(fileparts(mfilename('fullpath')),'..','..',modelType);
+filePath = fullfile(modelDirectory,fileName);
+iCreateDirectoryIfItDoesNotExist(modelDirectory);
+
+iDownloadFileIfItDoesNotExist( ...
+    filePath, ...
+    "https://ssd.mathworks.com/supportfiles/nnet/data/networks/"+fileName );
+end
+
+function iCreateDirectoryIfItDoesNotExist(directory)
+if ~exist(directory, 'dir')
+    fprintf('Creating directory ''%s''...\n', directory);
+    mkdir(directory);
+else
+    fprintf('Skipped creating directory ''%s'' as it already exists\n', directory);
+end
+end
+
+function iDownloadFileIfItDoesNotExist(destination, source)
+if ~exist(destination, 'file')
+    fprintf('Downloading file ''%s'' ...\n', destination);
+    websave(destination, source);
+else
+    fprintf('Skipped downloading file ''%s'' as it already exists\n', destination);
+end
 end

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ This repository implements deep learning transformer models in MATLAB.
 ## Getting Started
 Download or [clone](https://www.mathworks.com/help/matlab/matlab_prog/use-source-control-with-projects.html#mw_4cc18625-9e78-4586-9cc4-66e191ae1c2c) this repository to your machine and open it in MATLAB. 
 
-For R2020a or R2020b download the repo at the corresponding tagged release, or if you are using `git` then `git checkout <release>` where `<release>` is `R2020a` or `R2020b`.
-
 ## Functions
 ### bert
 `mdl = bert` loads a pretrained BERT transformer model and if necessary, downloads the model weights. The output `mdl` is structure with fields `Tokenizer` and `Parameters` that contain the BERT tokenizer and the model parameters, respectively.


### PR DESCRIPTION
We discussed this a while back, the idea is to support `gpt2` in R2020a and R2020b without requiring the user to checkout an old git commit.

This follows what happens on those old commits: data files are saved to the repo's root directory, rather than the userpath (as in the latest/21a commits). 

So what should happen:

- 21a and later users unaffected
- 20a and 20b users get same behaviour as they would by running `git checkout 2020a`

I should probably update the readme to remove the unnecessary instructions.