### PR TITLE
Add README_JP.md and a link to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![CircleCI](https://img.shields.io/circleci/build/github/matlab-deep-learning/transformer-models?label=tests)](https://app.circleci.com/pipelines/github/matlab-deep-learning/transformer-models)
 
 This repository implements deep learning transformer models in MATLAB.
+
 日本語のREADMEは[こちら](https://github.com/matlab-deep-learning/transformer-models/blob/master/README_JP.md)
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![CircleCI](https://img.shields.io/circleci/build/github/matlab-deep-learning/transformer-models?label=tests)](https://app.circleci.com/pipelines/github/matlab-deep-learning/transformer-models)
 
 This repository implements deep learning transformer models in MATLAB.
+日本語のREADMEは[こちら](https://github.com/matlab-deep-learning/transformer-models/blob/master/README_JP.md)
 
 ## Requirements
 ### BERT and FinBERT

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,7 +1,7 @@
 # MATLABのためのトランスフォーマーモデル
 [![CircleCI](https://img.shields.io/circleci/build/github/matlab-deep-learning/transformer-models?label=tests)](https://app.circleci.com/pipelines/github/matlab-deep-learning/transformer-models)
 
-*README in English is [here]](https://github.com/matlab-deep-learning/transformer-models/blob/master/README.md)
+*README in English is [here](https://github.com/matlab-deep-learning/transformer-models/blob/master/README.md)
 
 このリポジトリは、MATLABで深層学習トランスフォーマーモデルを実装するための関数や例題が含まれています。なお、BERT、finBERT、GPT-2は、基本的には、BERTの"multilingual-cased"を除き英語の文書を用いて学習されており、入力値も英語であることが想定されています。
 


### PR DESCRIPTION
Dear author,
I have translated the README.md into Japanese and created README_JP.md. I also added a link in README.md to switch to README_JP.md. I hope you could consider merging these two changes.